### PR TITLE
Fix: artwork likes count, artworks liked/disliked status, qr scanner

### DIFF
--- a/src/components/GalleryTile.tsx
+++ b/src/components/GalleryTile.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
-import { NavContext } from "@ionic/react";
+import React from "react";
 import { connect, ConnectedProps } from "react-redux";
 import "./GalleryTile.css";
 
@@ -71,7 +70,7 @@ const GalleryTile = (props: Props) => {
   let isDisliked = artDisplay.disliked
 
 
-//   const [isLiked, toggleIsLiked] = useState(artDisplay.liked);
+//   const [isLiked, setIsLiked] = useState(artDisplay.liked);
 //   const [isDisliked, toggleIsDisliked] = useState(artDisplay.disliked);
 
   return (
@@ -115,11 +114,8 @@ const GalleryTile = (props: Props) => {
                   size="small"
                   color="danger"
                   onClick={() => {
-                    // toggleLikedStatus(likedStatus => !likedStatus)
-                    // toggleDislikedStatus(dislikedStatus => !dislikedStatus)
                      props.clickLikeButton(user, artDisplay, true)
                     }}
-                  // onClick={handleLikes}
                 >
                   {isLiked? (
                     <IonIcon className="likeHeart" icon={heart}></IonIcon>
@@ -139,8 +135,6 @@ const GalleryTile = (props: Props) => {
                   size="small"
                   color="primary"
                   onClick={() => {
-                    // toggleDislikedStatus(dislikedStatus => !dislikedStatus)
-                    // toggleLikedStatus(likedStatus => !likedStatus)
                     props.clickDislikeButton(user, artDisplay)
                       
                     }}

--- a/src/components/QRScanner.tsx
+++ b/src/components/QRScanner.tsx
@@ -5,19 +5,21 @@
  * Sends scan result to parent QRScan page.
  */
 
-
-import React, { createRef } from 'react';
-import { IonButton, IonFab, IonFabButton, IonIcon, IonToast } from '@ionic/react';
-import './QRScanner.css';
-import jsQR from 'jsqr';
-
+import React, { createRef } from "react";
 import {
-  folder, scan, stop
-} from "ionicons/icons";
+  IonButton,
+  IonFab,
+  IonFabButton,
+  IonIcon,
+  IonToast,
+} from "@ionic/react";
+import "./QRScanner.css";
+import jsQR from "jsqr";
 
+import { folder, scan, stop } from "ionicons/icons";
 
 interface ContainerProps {
-  name: string
+  name: string;
   getHandleFile: any;
   scanResultParent: (qrcode: any) => void;
   scanStateParent: (state: any) => void;
@@ -25,10 +27,10 @@ interface ContainerProps {
 }
 
 interface ContainerState {
-  scanActive: boolean
-  scanResult: string
-  videoSrc: string
-  showInvalidQRToast: boolean
+  scanActive: boolean;
+  scanResult: string;
+  videoSrc: string;
+  showInvalidQRToast: boolean;
 }
 
 class QRScanner extends React.Component<ContainerProps, ContainerState> {
@@ -43,83 +45,94 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
   private stream: any;
   // private loading!: HTMLIonLoadingElement;
 
-
   constructor(props: ContainerProps) {
     super(props);
 
     this.state = {
       scanActive: false,
-      scanResult: '',
-      videoSrc: '',
-      showInvalidQRToast: false
-    }
+      scanResult: "",
+      videoSrc: "",
+      showInvalidQRToast: false,
+    };
 
     this.stream = new Response();
 
-    this.setShowInvalidQRToast = this.setShowInvalidQRToast.bind(this)
-    this.startScan = this.startScan.bind(this)
-    this.scan = this.scan.bind(this)
-    this.stopScan = this.stopScan.bind(this)
-    this.refresh = this.refresh.bind(this)
-    this.uploadImage = this.uploadImage.bind(this)
-    this.handleFile = this.handleFile.bind(this)
-    this.parseQRCode = this.parseQRCode.bind(this)
-
+    this.setShowInvalidQRToast = this.setShowInvalidQRToast.bind(this);
+    this.startScan = this.startScan.bind(this);
+    this.scan = this.scan.bind(this);
+    this.stopScan = this.stopScan.bind(this);
+    this.refresh = this.refresh.bind(this);
+    this.uploadImage = this.uploadImage.bind(this);
+    this.handleFile = this.handleFile.bind(this);
+    this.parseQRCode = this.parseQRCode.bind(this);
   }
 
   setShowInvalidQRToast(status: boolean) {
-    this.setState({ showInvalidQRToast: status })
+    this.setState({ showInvalidQRToast: status });
   }
 
   // When DOM is loaded, get references to canvas and video elements.
   componentDidMount() {
-    this.canvasElement = this.canvas.current!
-    this.videoElement = this.video.current!
-    this.canvasContext = this.canvasElement.getContext('2d')
-    this.fileInput = document.getElementById(`file-input${this.props.stylingMargins}`)
+    this.canvasElement = this.canvas.current!;
+    this.videoElement = this.video.current!;
+    this.canvasContext = this.canvasElement.getContext("2d");
+    this.fileInput = document.getElementById(
+      `file-input${this.props.stylingMargins}`
+    );
   }
 
   async componentDidUpdate() {
-    this.canvasElement = this.canvas.current!
-    this.canvasContext = this.canvasElement.getContext('2d')
-    this.videoElement = this.video.current!
-    this.fileInput = document.getElementById(`file-input${this.props.stylingMargins}`)
+    this.canvasElement = this.canvas.current!;
+    this.canvasContext = this.canvasElement.getContext("2d");
+    this.videoElement = this.video.current!;
+    this.fileInput = document.getElementById(
+      `file-input${this.props.stylingMargins}`
+    );
   }
 
   parseQRCode(code: String) {
-    console.log("parseQRCode")
-    if (code.startsWith('https://cuny-gallery.web.app/cuny-campus-art-' || 'campus-art' || 'campus-art-'))
-      return true
+    console.log("parseQRCode");
+    if (
+      code.startsWith(
+        "https://cuny-gallery.web.app/cuny-campus-art-" ||
+          "campus-art" ||
+          "campus-art-"
+      )
+    )
+      return true;
     else {
-      console.log('invalid qr code')
+      console.log("invalid qr code");
       // if(this.state.scanActive) this.stopScan();
-      this.setState({ showInvalidQRToast: true })
-      return false
+      this.setState({ showInvalidQRToast: true });
+      return false;
     }
   }
 
   // startScan() sets up the camera stream
   // As of now doesn't work on, iOS standalone mode
   async startScan() {
+    try {
+      //sends update to parent to let it know scan state is active
+      this.props.scanStateParent(true);
+      this.setState({ scanActive: true });
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" },
+      });
 
-    //sends update to parent to let it know scan state is active
-    this.props.scanStateParent(true)
+      this.videoElement.srcObject = this.stream;
+      // Required for Safari
+      this.videoElement.setAttribute("playsinline", true);
 
-    this.stream = await navigator.mediaDevices.getUserMedia({
-      video: { facingMode: 'environment' }
-    });
+      // this.loading = await this.loadingCtrl.create({});
+      // await this.loading.present();
 
-    this.setState({ scanActive: true });
-
-    this.videoElement.srcObject = this.stream;
-    // Required for Safari
-    this.videoElement.setAttribute('playsinline', true);
-
-    // this.loading = await this.loadingCtrl.create({});
-    // await this.loading.present();
-
-    this.videoElement.play();
-    requestAnimationFrame(this.scan);
+      this.videoElement.play();
+      requestAnimationFrame(this.scan);
+    } catch {
+      this.props.scanStateParent(false);
+      this.setState({ scanActive: false });
+    }
+    console.log(this.stream);
   }
 
   // scan() takes images from the camera stream and detects QR code
@@ -147,23 +160,22 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
         this.canvasElement.height
       );
       const code = jsQR(imageData.data, imageData.width, imageData.height, {
-        inversionAttempts: 'dontInvert'
+        inversionAttempts: "dontInvert",
       });
 
-     // console.log(code);
+      // console.log(code);
 
       if (code) {
-
-        let isValidQRCode = this.parseQRCode(code.data)
+        let isValidQRCode = this.parseQRCode(code.data);
 
         // When a result is found, video stops, and scanResult Parent is called. scanResultParent tries to update state of overall app,
         if (isValidQRCode) {
-          console.log(this.props.scanResultParent, "ScanResultParent")
-          this.videoElement.setAttribute('playsinline', false);
+          console.log(this.props.scanResultParent, "ScanResultParent");
+          this.videoElement.setAttribute("playsinline", false);
           this.stream.getTracks()[0].stop();
           this.setState({
             scanActive: false,
-            scanResult: code.data
+            scanResult: code.data,
           });
 
           this.props.scanResultParent(code.data);
@@ -171,38 +183,39 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
         } else {
           requestAnimationFrame(this.scan);
         }
-
       } else {
-        if (this.state.scanActive)
-          requestAnimationFrame(this.scan);
+        if (this.state.scanActive) requestAnimationFrame(this.scan);
       }
     } else {
       requestAnimationFrame(this.scan);
     }
   }
 
-
   // Stops stream when user presses stop button and sets the state of scanActive to false
   stopScan() {
-    this.props.scanStateParent(false)//sends update to parent to let it know scan state is not active
-    this.videoElement.setAttribute('playsinline', false);
+    this.props.scanStateParent(false); //sends update to parent to let it know scan state is not active
+    this.videoElement.setAttribute("playsinline", false);
     this.stream.getTracks()[0].stop();
     this.setState({ scanActive: false });
   }
 
   refresh() {
     this.stream.getTracks()[0].stop();
-    this.setState({ scanResult: '', scanActive: false });
+    this.setState({ scanResult: "", scanActive: false });
   }
-
 
   // Handles uploaded image
   handleFile(event: React.ChangeEvent<HTMLElement>) {
     let file = this.fileInput.files.item(0);
-    console.log("GOOAL")
     var img = new Image();
     img.onload = () => {
-      this.canvasContext.drawImage(img, 0, 0, this.canvasElement.width, this.canvasElement.height);
+      this.canvasContext.drawImage(
+        img,
+        0,
+        0,
+        this.canvasElement.width,
+        this.canvasElement.height
+      );
       const imageData = this.canvasContext.getImageData(
         0,
         0,
@@ -210,48 +223,51 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
         this.canvasElement.height
       );
       const code = jsQR(imageData.data, imageData.width, imageData.height, {
-        inversionAttempts: 'dontInvert'
+        inversionAttempts: "dontInvert",
       });
 
-
+      // If a QR code is scanned will attempt to retrieve from data base, if unsuccessful, will show invalid toast
+      // Else if an image without a QR code is scanned, will show invalid toast
       if (code) {
-
-
-
-        let isValidQRCode = this.parseQRCode(code.data)
+        let isValidQRCode = this.parseQRCode(code.data);
 
         if (isValidQRCode) {
           this.setState({ scanResult: code.data });
           this.props.scanResultParent(code.data);
         } else {
-          this.setState({ showInvalidQRToast: true })
+          this.setState({ showInvalidQRToast: true });
         }
+      } else {
+        this.setState({ showInvalidQRToast: true });
       }
     };
     img.src = URL.createObjectURL(file);
-
   }
 
   uploadImage() {
     // Turns off scanner if uploadImage button is pressed
     if (this.state.scanActive) {
       this.stream.getTracks()[0].stop();
-      this.setState({ scanActive: false })
+      this.setState({ scanActive: false });
     }
     // Clicks hidden input file button
     this.fileInput.click();
   }
 
   render() {
-    this.props.getHandleFile(this.handleFile)
+    this.props.getHandleFile(this.handleFile);
     return (
       <div className={this.props.stylingMargins}>
         {/* <strong>{this.props.name}</strong> */}
 
-
         {/* -- Fallback for iOS PWA -- */}
-        <input id={`file-inputqr-scanner-scan-section`} type="file" accept="image/*;capture=camera" hidden onChange={this.handleFile} />
-
+        <input
+          id={`file-inputqr-scanner-scan-section`}
+          type="file"
+          accept="image/*;capture=camera"
+          hidden
+          onChange={this.handleFile}
+        />
 
         {/* --Trigger the file input-- */}
         {/* <IonFab vertical="bottom" horizontal="start" slot="fixed">
@@ -260,10 +276,9 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
           </IonFabButton>
         </IonFab> */}
 
-
         <IonButton
           className="ion-no-margin QR-button"
-          style={{ marginBottom: '5px' }}
+          style={{ marginBottom: "5px" }}
           expand="block"
           size="large"
           id="scan-button"
@@ -276,7 +291,7 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
 
         <IonButton
           className="ion-no-margin QR-button"
-          style={{ marginBottom: '5px' }}
+          style={{ marginBottom: "5px" }}
           expand="block"
           // size="medium"
           id="camera"
@@ -286,7 +301,6 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
           <IonIcon slot="end" icon={folder} />
           Upload QR Image
         </IonButton>
-
 
         {/* <IonFooter>
         <IonButton
@@ -300,18 +314,29 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
 
         <div id="scanner-section">
           {/* --Shows our camera stream-- */}
-          <video className="video-scanner" hidden={!this.state.scanActive} width="100%" ref={this.video} autoPlay={true} />
+          <video
+            className="video-scanner"
+            hidden={!this.state.scanActive}
+            width="100%"
+            ref={this.video}
+            autoPlay={true}
+          />
 
           {/* --Used to render the camera stream images-- */}
           <canvas hidden ref={this.canvas}></canvas>
-
         </div>
 
-        {this.state.scanActive ? <IonFab vertical="bottom" horizontal="end" slot="fixed">
-          <IonFabButton id='stop-button' color="danger" onClick={this.stopScan} >
-            <IonIcon color='light' icon={stop}></IonIcon>
-          </IonFabButton>
-        </IonFab> : null}
+        {this.state.scanActive ? (
+          <IonFab vertical="bottom" horizontal="end" slot="fixed">
+            <IonFabButton
+              id="stop-button"
+              color="danger"
+              onClick={this.stopScan}
+            >
+              <IonIcon color="light" icon={stop}></IonIcon>
+            </IonFabButton>
+          </IonFab>
+        ) : null}
 
         <IonToast
           id="invalid-qr-toast"
@@ -331,13 +356,8 @@ class QRScanner extends React.Component<ContainerProps, ContainerState> {
           <IonCardContent>{this.state.scanResult}</IonCardContent>
         </IonCard> */}
 
-
         {/* Fall Back Non QR Scanner Camera - not functional as of yet*/}
-
-
-
-      </ div>
-
+      </div>
     );
   }
 }

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -16,7 +16,6 @@ import {
   IonCardTitle,
   IonInput,
   IonLabel,
-  IonText,
   IonToast,
   IonSegment,
   IonSegmentButton,
@@ -83,7 +82,7 @@ const UserProfile = (props: Props) => {
   const saveChanges = async () => {
     console.log(profileEdits);
     setLoading(true);
-    let res = await props.editUser(profileEdits);
+    await props.editUser(profileEdits);
     setLoading(false);
   }
 

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -5,9 +5,9 @@
  * of past artworks the user has scanned locally.
  */
 
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback, useContext } from "react";
 import { connect, ConnectedProps } from "react-redux";
-import { IonItem, IonList, IonText, NavContext } from "@ionic/react";
+import { IonList, NavContext } from "@ionic/react";
 import "./Gallery.css";
 import GalleryTile from '../components/GalleryTile'
 import type { ArtDisplay } from "../store/models";

--- a/src/pages/ScanQR.tsx
+++ b/src/pages/ScanQR.tsx
@@ -60,7 +60,7 @@ const ScanQR = (props: Props) => {
 
   let [scanResult, setScanResult] = useState("");
 
-  //This will cover cases where outdated QR Codes (i.e. artworks that don't exist anymore) are scanned
+  //This will cover cases where invalid or outdated QR Codes (i.e. artworks that don't exist anymore) are scanned
   const [showNotFoundToast, setNotFoundToast] = useState(false);
 
   let scanResultParent = async (qrCodeText: string) => {
@@ -81,7 +81,7 @@ const ScanQR = (props: Props) => {
   };
 
   // Causes camera button to toggle on and off based on whether scan is open. When scan is open, camera button is replaced by a stop button, goes back to normal otherwise.
-  //Also causes div with blackground to fillup screen for better aesthetic during scan mode
+  // Also causes div with background to fillup screen for better aesthetic during scan mode
   // Checks whether scan state in child QRScanner component is active
   let [scanState, setScanState] = useState(0);
 

--- a/src/pages/ScavengerHunt.tsx
+++ b/src/pages/ScavengerHunt.tsx
@@ -44,7 +44,7 @@ type Props = PropsFromRedux & {
 
 const ScavengerHunt = (props: Props) => {
 
-  // Loads clues
+  // Loads clues when component initially mounts
   useEffect(() => { if (user) props.initializeUser(props.currentUser); }, []);
 
   let user = props.currentUser;

--- a/src/store/artdisplay.ts
+++ b/src/store/artdisplay.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { StrapiApiConnection } from "./util";
 
 import type { ArtDisplay, Video, ArtDisplaysState, User } from "./models";
@@ -246,7 +245,6 @@ export function addVideo(video: Video): ArtDisplayActionTypes {
   };
 }
 /*** THUNK CREATORS TO FETCH INFO FROM DATABASE ****/
-const strapiUrl = "https://dev-cms.cunycampusart.com";
 
 /** fetchPastArtworks
  * fetches user's past artworks information and adds on like and disliked status for each artwork
@@ -257,7 +255,8 @@ export const fetchPastArtworks = (user: any) => async (dispatch: any) => {
     con.formatArtwork(artwork)
   );
 
-  // let artworks = addLikedDislikedToArtworks(user)
+  // Add on liked and disliked status for each artwork
+  con.addLikedDislikedToArtworks(user)
   dispatch(gotPastArtDisplays(user.scanned_artworks));
   //return artworks;
 };
@@ -405,11 +404,10 @@ export const clickLikeButton =
     }
 
     // If artwork is already liked, remove from likes
-    if (user && artwork.liked === true) {
+    if (user && artwork.liked) {
       await removeFromLikes(dispatch, artwork);
-      await con.decreaseLikesForArtworkById(artwork.id);
     } else {
-      if (user && artwork.liked === false) {
+      if (user && !artwork.liked) {
         // Add to Likes
         artwork.liked = true;
 
@@ -459,10 +457,10 @@ export const clickDislikeButton =
       return;
     }
     // If artwork is already disliked, remove from dislikes
-    if (user && artwork.disliked === true) {
+    if (user && artwork.disliked) {
       await removeFromDislikes(artwork);
     } else {
-      if (user && artwork.disliked === false) {
+      if (user && !artwork.disliked) {
         // Add to Dislikes
         artwork.disliked = true;
 

--- a/src/store/models.ts
+++ b/src/store/models.ts
@@ -26,7 +26,7 @@ export interface ArtDisplay {
 }
 
 // for initial state
-export const defaultCurrentArtDisplay = {
+export let defaultCurrentArtDisplay = {
   id: "default",
   title: "New York City",
   artist: "Frédéric Thery",

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import type { User, UserState } from './models'
+import type { User } from './models'
 import { fetchPastArtworks, fetchUnsolvedArtworks } from './artdisplay'
 import { hashPassword } from "./hashPassword";
 import { StrapiApiConnection } from "./util";
@@ -227,7 +227,7 @@ const defaultUser =
 
 /*********** TYPE CHECKING REDUCERS **********/
 
-export default function (state = defaultUser, action: any) {
+export default function (state = defaultUser, action: UserActionTypes) {
   switch (action.type) {
     case GET_USER:
       localStorage.setItem('user', JSON.stringify(action.payload))

--- a/src/store/util.js
+++ b/src/store/util.js
@@ -586,7 +586,6 @@ Returns: api request reponse
     // Moving this async call because it makes formatting the user info much longer than it needs to be.
     //formattedUser.unsolved_artworks = await this.getUnsolvedArtworks(formattedUser)
 
-    console.log(formattedUser, "after inside formatArtwork");
     return formattedUser;
   };
 
@@ -782,7 +781,6 @@ Returns: api request reponse
         "liked_artworks",
         artworkIdArray
       );
-      console.log("THIS IS HTE RESPONSE for LIKESD");
     } catch (error) {
       console.log(error);
       return { status: 400 };


### PR DESCRIPTION
Artwork: 

- (fix) Artwork's likes count increment/ decrement correctly

- (fix) Artwork's liked and disliked status persists on refresh

QR Scanner: 
- (fix) Show invalid toast when an image that has no QR code is uploaded/ scanned (valid QR codes - whether in database or not- already taken care of)
- (fix) There is an error in the app when the user denies camera access. The QR Scanner stayed on scan mode without any stream and without a stop button. Fixed this error, where QR scanner is disabled if media stream is not successfully retrieved.

- (refactor): reformatted files using Prettier and cleaned up unused variables and console.log statements